### PR TITLE
Adjust zoom sensitivity

### DIFF
--- a/js/monkeypuzzle.js
+++ b/js/monkeypuzzle.js
@@ -138,7 +138,7 @@ function initCytoscape() {
             selectionType: "single",
             minZoom: 0.1,
             maxZoom: 1.5,
-            wheelSensitivity: 0.2
+            wheelSensitivity: 0.1
     });
 
     layout = build_cola_layout();

--- a/js/monkeypuzzle.js
+++ b/js/monkeypuzzle.js
@@ -137,7 +137,8 @@ function initCytoscape() {
             autounselectify: false,
             selectionType: "single",
             minZoom: 0.1,
-            maxZoom: 1.5
+            maxZoom: 1.5,
+            wheelSensitivity: 0.2
     });
 
     layout = build_cola_layout();


### PR DESCRIPTION
## The Problem

When using MonkeyPuzzle the zoom increment is too harsh - often I find myself wanting to zoom out in my canvas and then zooming out too far even though it's the next zoom "step".

## The Solution

This change adjusts the sensitivity of the mouse wheel within the canvas so zooming is smoother and in lower increments.
The added `wheelSensitivity` value can be adjusted to make the zoom increment higher or lower respectively.

## Comparison

Before:

[![Image from Gyazo](https://i.gyazo.com/b47dd98e09779280026ec57e10be25f7.gif)](https://gyazo.com/b47dd98e09779280026ec57e10be25f7)

After:

[![Image from Gyazo](https://i.gyazo.com/b1f5db2a8aa6c1978ed25d1d8a33133b.gif)](https://gyazo.com/b1f5db2a8aa6c1978ed25d1d8a33133b)